### PR TITLE
fix(postinstall): getting stuck in a loop in yarn

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+npx pinst --disable --silent
 
 # copy husky config
 cp -u ./dist/.huskyrc $1/.huskyrc && echo 'copied .huskyrc'
@@ -25,3 +26,5 @@ fi
 
 $cmd >/dev/null 2>&1
 echo $msg
+
+npx pinst --enable --silent


### PR DESCRIPTION
used `pinst` package to disable postinstall scripts so that it only runs once. it was getting stuck
in a loop when installed by yarn